### PR TITLE
TWAP oracle & gas efficiency

### DIFF
--- a/src/Space.sol
+++ b/src/Space.sol
@@ -553,9 +553,9 @@ contract Space is IMinimalSwapInfoPool, BalancerPoolToken, PoolPriceOracle {
 
             // Make a small pseudo swap to determine the instantaneous spot price
             uint256 targetOut = _onSwap(
-                true, 
-                true, 
-                1e12, 
+                true, // zero in
+                true, // given in
+                1e12, // 1e12 zeros in
                 balanceZero.add(totalSupply()), 
                 balanceTarget.mulDown(_initScale)
             );

--- a/src/Space.sol
+++ b/src/Space.sol
@@ -431,7 +431,7 @@ contract Space is IMinimalSwapInfoPool, BalancerPoolToken, PoolPriceOracle {
         uint256 amountDelta,
         uint256 reservesTokenIn,
         uint256 reservesTokenOut
-    ) internal returns (uint256) {
+    ) internal view returns (uint256) {
         // xPre = token in reserves pre swap
         // yPre = token out reserves pre swap
 
@@ -492,6 +492,8 @@ contract Space is IMinimalSwapInfoPool, BalancerPoolToken, PoolPriceOracle {
             return 0;
         }
 
+        // Equation inspired by `WeightedMath.sol` in PR#1111 in the Balancer monorepo,
+        // which also needs to calculate fees based on growth in the invariant
         uint256 growth = fullInvariant.divDown(timeOnlyInvariant);
         uint256 k = protocolSwapFeePercentage.mulDown(growth.sub(FixedPoint.ONE)).divDown(growth);
 

--- a/src/Space.sol
+++ b/src/Space.sol
@@ -552,14 +552,15 @@ contract Space is IMinimalSwapInfoPool, BalancerPoolToken, PoolPriceOracle {
         if (oracleData.oracleEnabled && block.number > lastChangeBlock && balanceTarget >= 1e16) {
 
             // Make a small pseudo swap to determine the instantaneous spot price
-            uint256 targetOut = _onSwap(
+            uint256 underlyingOut = _onSwap(
                 true, // zero in
                 true, // given in
                 1e12, // 1e12 zeros in
                 balanceZero.add(totalSupply()), 
                 balanceTarget.mulDown(_initScale)
             );
-            uint256 zeroPrice = targetOut.divDown(AdapterLike(adapter).scale()).divDown(1e12);
+            // Cacluate the price of one Zero in Target terms
+            uint256 zeroPrice = underlyingOut.divDown(AdapterLike(adapter).scale()).divDown(1e12);
 
             uint256 oracleUpdatedIndex = _processPriceData(
                 oracleData.oracleSampleInitialTimestamp,

--- a/src/Space.sol
+++ b/src/Space.sol
@@ -183,12 +183,11 @@ contract Space is IMinimalSwapInfoPool, BalancerPoolToken, PoolPriceOracle {
         _upscaleArray(reqAmountsIn);
 
         if (totalSupply() == 0) {
-            (uint256 _pti, uint256 _targeti) = getIndices();
             uint256 initScale = AdapterLike(adapter).scale();
 
             // Convert target balance into Underlying
             // note: We assume scale values will always be 18 decimals
-            uint256 underlyingIn = reqAmountsIn[_targeti].mulDown(initScale);
+            uint256 underlyingIn = reqAmountsIn[1 - pti].mulDown(initScale);
 
             // Just like weighted pool 2 token from the balancer v2 monorepo,
             // we lock MINIMUM_BPT in by minting it for the PT address. This reduces potential
@@ -206,7 +205,7 @@ contract Space is IMinimalSwapInfoPool, BalancerPoolToken, PoolPriceOracle {
 
             // For the first join, we don't pull any PT, regardless of what the caller requested.
             // This starts this pool off as synthetic Underlying only, as the yieldspace invariant expects
-            delete reqAmountsIn[_pti];
+            delete reqAmountsIn[pti];
 
             // Cache starting Target reserves
             reserves = reqAmountsIn;
@@ -383,24 +382,23 @@ contract Space is IMinimalSwapInfoPool, BalancerPoolToken, PoolPriceOracle {
         returns (uint256, uint256[] memory)
     {
         // Disambiguate reserves wrt token type
-        (uint256 _pti, uint256 _targeti) = getIndices();
-        (uint256 principalReserves, uint256 targetReserves) = (reserves[_pti], reserves[_targeti]);
+        (uint256 principalReserves, uint256 targetReserves) = (reserves[pti], reserves[1 - pti]);
 
         uint256[] memory amountsIn = new uint256[](2);
 
         // If the pool has been initialized, but there aren't yet any PT in it
         if (principalReserves == 0) {
-            uint256 reqTargetIn = reqAmountsIn[_targeti];
+            uint256 reqTargetIn = reqAmountsIn[1 - pti];
             // Mint LP shares according to the relative amount of Target being offered
             uint256 bptToMint = BasicMath.mul(totalSupply(), reqTargetIn) / targetReserves;
 
             // Pull the entire offered Target
-            amountsIn[_targeti] = reqTargetIn;
+            amountsIn[1 - pti] = reqTargetIn;
 
             return (bptToMint, amountsIn);
         } else {
             // Disambiguate requested amounts wrt token type
-            (uint256 reqPrincipalIn, uint256 reqTargetIn) = (reqAmountsIn[_pti], reqAmountsIn[_targeti]);
+            (uint256 reqPrincipalIn, uint256 reqTargetIn) = (reqAmountsIn[pti], reqAmountsIn[1 - pti]);
             // Caclulate the percentage of the pool we'd get if we pulled all of the requested Target in
             uint256 bptToMintTarget = BasicMath.mul(totalSupply(), reqTargetIn) / targetReserves;
 
@@ -409,13 +407,13 @@ contract Space is IMinimalSwapInfoPool, BalancerPoolToken, PoolPriceOracle {
 
             // Determine which amountIn is our limiting factor
             if (bptToMintTarget < bptToMintPT) {
-                amountsIn[_pti] = BasicMath.mul(principalReserves, reqTargetIn) / targetReserves;
-                amountsIn[_targeti] = reqTargetIn;
+                amountsIn[pti] = BasicMath.mul(principalReserves, reqTargetIn) / targetReserves;
+                amountsIn[1 - pti] = reqTargetIn;
 
                 return (bptToMintTarget, amountsIn);
             } else {
-                amountsIn[_pti] = reqPrincipalIn;
-                amountsIn[_targeti] = BasicMath.mul(targetReserves, reqPrincipalIn) / principalReserves;
+                amountsIn[pti] = reqPrincipalIn;
+                amountsIn[1 - pti] = BasicMath.mul(targetReserves, reqPrincipalIn) / principalReserves;
 
                 return (bptToMintPT, amountsIn);
             }

--- a/src/SpaceFactory.sol
+++ b/src/SpaceFactory.sol
@@ -52,18 +52,23 @@ contract SpaceFactory is Trust {
     uint256 public g1;
     uint256 public g2;
 
+    /// @notice Oracle flag
+    bool public oracleEnabled;
+
     constructor(
         IVault _vault,
         address _divider,
         uint256 _ts,
         uint256 _g1,
-        uint256 _g2
+        uint256 _g2,
+        bool _oracleEnabled
     ) Trust(msg.sender) {
         vault = _vault;
         divider = _divider;
         ts = _ts;
         g1 = _g1;
         g2 = _g2;
+        oracleEnabled = _oracleEnabled;
     }
 
     /// @notice Deploys a new `Space` contract
@@ -80,7 +85,8 @@ contract SpaceFactory is Trust {
             ),
             ts,
             g1,
-            g2
+            g2,
+            oracleEnabled
         ));
 
         pools[adapter][maturity] = pool;
@@ -89,7 +95,8 @@ contract SpaceFactory is Trust {
     function setParams(
         uint256 _ts,
         uint256 _g1,
-        uint256 _g2
+        uint256 _g2,
+        bool _oracleEnabled
     ) public requiresTrust {
         // g1 is for swapping Targets to Zeros and should discount the effective interest
         _require(_g1 <= FixedPoint.ONE, Errors.INVALID_G1);
@@ -99,5 +106,6 @@ contract SpaceFactory is Trust {
         ts = _ts;
         g1 = _g1;
         g2 = _g2;
+        oracleEnabled = _oracleEnabled;
     }
 }

--- a/src/tests/SpaceFactory.t.sol
+++ b/src/tests/SpaceFactory.t.sol
@@ -57,7 +57,14 @@ contract SpaceFactoryTest is DSTest {
 
         Authorizer authorizer = new Authorizer(address(this));
         vault = new Vault(authorizer, weth, 0, 0);
-        spaceFactory = new SpaceFactory(vault, address(divider), ts, g1, g2);
+        spaceFactory = new SpaceFactory(
+            vault,
+            address(divider),
+            ts,
+            g1,
+            g2,
+            true
+        );
     }
 
     function testCreatePool() public {
@@ -84,7 +91,7 @@ contract SpaceFactoryTest is DSTest {
         ts = FixedPoint.ONE.divDown(FixedPoint.ONE * 100);
         g1 = (FixedPoint.ONE * 900).divDown(FixedPoint.ONE * 1000);
         g2 = (FixedPoint.ONE * 1000).divDown(FixedPoint.ONE * 900);
-        spaceFactory.setParams(ts, g1, g2);
+        spaceFactory.setParams(ts, g1, g2, true);
         space = Space(spaceFactory.create(address(adapter), maturity2));
 
         // If params are updated, the new ones are used in the next deployment
@@ -94,14 +101,14 @@ contract SpaceFactoryTest is DSTest {
 
         // Fee params are validated
         g1 = (FixedPoint.ONE * 1000).divDown(FixedPoint.ONE * 900);
-        try spaceFactory.setParams(ts, g1, g2) {
+        try spaceFactory.setParams(ts, g1, g2, true) {
             fail();
         } catch Error(string memory error) {
             assertEq(error, Errors.INVALID_G1);
         }
         g1 = (FixedPoint.ONE * 900).divDown(FixedPoint.ONE * 1000);
         g2 = (FixedPoint.ONE * 900).divDown(FixedPoint.ONE * 1000);
-        try spaceFactory.setParams(ts, g1, g2) {
+        try spaceFactory.setParams(ts, g1, g2, true) {
             fail();
         } catch Error(string memory error) {
             assertEq(error, Errors.INVALID_G2);

--- a/src/tests/utils/VM.sol
+++ b/src/tests/utils/VM.sol
@@ -17,4 +17,13 @@ abstract contract VM {
     ) public virtual;
 
     function ffi(string[] calldata) public virtual returns (bytes memory);
+
+    // Sets the *next* call's msg.sender to be the input address, and the tx.origin to be the second input
+    function prank(address,address) virtual external;
+
+    // Sets all subsequent calls' msg.sender to be the input address until `stopPrank` is called, and the tx.origin to be the second input
+    function startPrank(address,address) virtual external;
+
+    // Resets subsequent calls' msg.sender to be `address(this)`
+    function stopPrank() virtual external;
 }


### PR DESCRIPTION
This PR includes:
* An operational Space TWAP (based on the implementation in [Balancer's weighted pool 2 tokens](https://github.com/balancer-labs/balancer-v2-monorepo/blob/c40b9a783e328d817892693bd13b4a14e4dcff4d/pkg/pool-weighted/contracts/WeightedPool2Tokens.sol))
* An update to the space factory allowing the admin to enable or disable the oracle for future pools
* Additional comments (notable around protocol fees)
* A few gas optimizations (using `zeroi` directly where the benefit is large, `Space:511` if-else efficiency, etc)
* A new oracle test and an expanded protocol fee test