### PR TITLE
refactor: rely on underlying req for pt 0 case

### DIFF
--- a/src/Space.sol
+++ b/src/Space.sol
@@ -194,7 +194,7 @@ contract Space is IMinimalSwapInfoPool, BalancerPoolToken, PoolPriceOracle {
             uint256 underlyingIn = reqAmountsIn[1 - pti].mulDown(initScale);
 
             // Just like weighted pool 2 token from the balancer v2 monorepo,
-            // we lock minBpt in by minting it for the PT address. This reduces potential
+            // we lock MINIMUM_BPT in by minting it for the PT address. This reduces potential
             // issues with rounding and ensures that this code path will only be executed once
             _mintPoolTokens(address(0), MINIMUM_BPT);
 
@@ -616,8 +616,8 @@ contract Space is IMinimalSwapInfoPool, BalancerPoolToken, PoolPriceOracle {
                 .divDown(balanceTarget.mulDown(_initScale));
 
             // Guard against rounding from exits leading the implied rate to be very slightly negative
-            // NOTE: in a future version of this system, we will preserve the postive rate invariant from joins/exits
-            // as we do for swaps
+            // NOTE: in a future version of this system, a postive rate invariant for joins/exits will be preserved,
+            // as is currently done for swaps
             impliedRate = impliedRate < FixedPoint.ONE ? 0 : impliedRate.sub(FixedPoint.ONE);
 
             // Cacluate the price of one PT in Target terms

--- a/src/Space.sol
+++ b/src/Space.sol
@@ -407,7 +407,7 @@ contract Space is IMinimalSwapInfoPool, BalancerPoolToken, PoolPriceOracle {
         if (pTReserves == 0) {
             uint256 reqTargetIn = reqAmountsIn[1 - pti];
             // Mint LP shares according to the relative amount of Target being offered
-            uint256 bptToMint = BasicMath.mul(totalSupply(), reqTargetIn) / targetReserves;
+            uint256 bptToMint = reqTargetIn.mulDown(_initScale);
 
             // Pull the entire offered Target
             amountsIn[1 - pti] = reqTargetIn;

--- a/src/tests/Space.t.sol
+++ b/src/tests/Space.t.sol
@@ -279,15 +279,13 @@ contract SpaceTest is Test {
         assertEq(balances[1 - space.pti()], space.MINIMUM_BPT().divDown(INIT_SCALE));
         vm.roll(2);
 
-        // Join uses ratio of totalSupply() / target reserves, which is small here
-        // so the join will be affected heavily by the rounding from the exit
+        // Pre-swap join uses target in times init_scale to determine the bpt given out
         uint256 TARGET_IN = 50e18;
         sid.join(0, TARGET_IN);
         uint256 joinedTargetInUnderlying = TARGET_IN.mulDown(INIT_SCALE);
         uint256 postSupply = space.totalSupply();
 
-        assertGt(postSupply, preSupply + joinedTargetInUnderlying);
-        assertTrue(!isClose(postSupply, preSupply + joinedTargetInUnderlying, 1e12));
+        assertEq(postSupply, preSupply + joinedTargetInUnderlying);
 
         vm.roll(3);
         sid.swapIn(true, 20e18);


### PR DESCRIPTION
As discussed after the review, this PR brings:
* use init scale to determine BPT out as long as the pt side has zero
* small gas opti with totalSupply
* a guard against rounding issues in the implied rate calc
* correct downscale <> cache ordering