### PR TITLE
GEN-821: chore(Space.t): remove Test contract and use DSTest from sense-v1

### DIFF
--- a/src/tests/Space.t.sol
+++ b/src/tests/Space.t.sol
@@ -22,42 +22,7 @@ import {SpaceFactory} from "../SpaceFactory.sol";
 import {Space} from "../Space.sol";
 import {Errors} from "../Errors.sol";
 
-// Base DSTest plus a few extra features
-contract Test is DSTest {
-    function assertClose(
-        uint256 a,
-        uint256 b,
-        uint256 _tolerance
-    ) public {
-        bool _isClose = isClose(a, b, _tolerance);
-        if (!_isClose) {
-            emit log("Error: abs(a, b) < tolerance not satisfied [uint]");
-            emit log_named_uint("  Expected", b);
-            emit log_named_uint("  Tolerance", _tolerance);
-            emit log_named_uint("    Actual", a);
-            fail();
-        }
-    }
-
-    function isClose(
-        uint256 a,
-        uint256 b,
-        uint256 _tolerance
-    ) public view returns (bool) {
-        uint256 diff = a < b ? b - a : a - b;
-        return diff <= _tolerance;
-    }
-
-    function fuzzWithBounds(
-        uint256 amount,
-        uint256 lBound,
-        uint256 uBound
-    ) internal returns (uint256) {
-        return lBound + (amount % (uBound - lBound));
-    }
-}
-
-contract SpaceTest is Test {
+contract SpaceTest is DSTest {
     using FixedPoint for uint256;
 
     VM internal constant vm = VM(HEVM_ADDRESS);


### PR DESCRIPTION
As part of GEN-821 on Sense v1 ([PR#234](https://github.com/sense-finance/sense-v1/pull/234)), I've moved some helper functions (eg. `assertClose`, `fuzzWithBounds`) to `test.sol` to consolidate them into one place. Hence, this PR removes the Test contract which contained those function that already existed in Sense v1.