### PR TITLE
refactor: derive lp name/symbol from pt name/symbol

### DIFF
--- a/src/Space.sol
+++ b/src/Space.sol
@@ -13,7 +13,6 @@ import { IMinimalSwapInfoPool } from "@balancer-labs/v2-vault/contracts/interfac
 import { IVault } from "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
 import { IERC20 } from "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20.sol";
 
-import { DateTime } from "./utils/DateTime.sol";
 import { Errors, _require } from "./Errors.sol";
 import { PoolPriceOracle } from "./oracle/PoolPriceOracle.sol";
 
@@ -135,7 +134,10 @@ contract Space is IMinimalSwapInfoPool, BalancerPoolToken, PoolPriceOracle {
         uint256 _g1,
         uint256 _g2,
         bool _oracleEnabled
-    ) BalancerPoolToken(_name(_adapter, _maturity), _symbol(_adapter, _maturity)) {
+    ) BalancerPoolToken(
+        string(abi.encodePacked("Sense Space ", ERC20(pt).name())),
+        string(abi.encodePacked("SPACE-", ERC20(pt).symbol()))
+    ) {
         bytes32 poolId = vault.registerPool(IVault.PoolSpecialization.TWO_TOKEN);
 
         address target = AdapterLike(_adapter).target();
@@ -797,19 +799,6 @@ contract Space is IMinimalSwapInfoPool, BalancerPoolToken, PoolPriceOracle {
     function _downscaleUpArray(uint256[] memory amounts) internal view {
         amounts[pti] = BasicMath.divUp(amounts[pti], _scalingFactor(true));
         amounts[1 - pti] = BasicMath.divUp(amounts[1 - pti], _scalingFactor(false));
-    }
-
-    /* ========== INTERNAL UTILS ========== */
-
-    function _name(address _adapter, uint256 _maturity) internal returns (string memory name) {
-        string memory date = DateTime.format(_maturity);
-        name = string(abi.encodePacked(date, " ", ERC20(AdapterLike(_adapter).target()).name(), " Space LP"));
-    }
-
-    function _symbol(address _adapter, uint256 _maturity) internal returns (string memory symbol) {
-        (string memory d, string memory m, string memory y) = DateTime.toDateString(_maturity);
-        string memory datestring = string(abi.encodePacked(d, "-", m, "-", y));
-        symbol = string(abi.encodePacked("Space-LP-", ERC20(AdapterLike(_adapter).target()).symbol(), ":", datestring));
     }
 
     /* ========== MODIFIERS ========== */

--- a/src/tests/Space.t.sol
+++ b/src/tests/Space.t.sol
@@ -131,23 +131,8 @@ contract SpaceTest is DSTest {
         assertEq(pool.ts(), ts);
         assertEq(pool.g1(), g1);
         assertEq(pool.g2(), g2);
-        assertEq(pool.name(), "3rd July 1970 Target Token Space LP");
-        assertEq(pool.symbol(), "Space-LP-TT:03-07-1970");
-
-        // Test Space deployment with a recent maturity
-        maturity = 1650499200; // 21-04-2022:00:00:00 UTC
-        pool = new Space(
-            vault,
-            address(adapter),
-            maturity,
-            pt,
-            ts,
-            g1,
-            g2,
-            true
-        );
-        assertEq(pool.name(), "21st Apr 2022 Target Token Space LP");
-        assertEq(pool.symbol(), "Space-LP-TT:21-04-2022");
+        assertEq(pool.name(), "Sense Space 4th Oct 2021 cDAI Sense Principal Token, A2");
+        assertEq(pool.symbol(), "SPACE-sP-cDAI:04-10-2021:2");
     }
 
     function testJoinOnce() public {

--- a/src/tests/utils/Mocks.sol
+++ b/src/tests/utils/Mocks.sol
@@ -58,8 +58,16 @@ contract MockDividerSpace is DividerLike {
     mapping(uint256 => bool) public maturities;
 
     constructor(uint8 principalYieldDecimals) public {
-        ERC20Mintable _pt = new ERC20Mintable("pt", "pt", principalYieldDecimals);
-        ERC20Mintable _yt = new ERC20Mintable("yt", "yt", principalYieldDecimals);
+        ERC20Mintable _pt = new ERC20Mintable(
+            "4th Oct 2021 cDAI Sense Principal Token, A2",
+            "sP-cDAI:04-10-2021:2",
+            principalYieldDecimals
+        );
+        ERC20Mintable _yt = new ERC20Mintable(
+            "4th Oct 2021 cDAI Sense Yield Token, A2",
+            "sY-cDAI:04-10-2021:2",
+            principalYieldDecimals
+        );
 
         ptAddress = address(_pt);
         ytAddress = address(_yt);


### PR DESCRIPTION
## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Reduce the Space Factory's contract size to below the contract size limit (24576 bytes), which it currently exceeds by more than three kb even without any optimizer runs

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Remove the internal functions that rely on the `DateTime` library so that none of that library's code gets inlined. Instead, derive the name/symbol from the PT tokens' name/symbol, which already have formatted maturity dates. 

One drawback of this is that PT tokens' names/symbols have parts that are meant to indicate that the token is a PT, like "cDAI Sense Principal Token", and it might be confusing to see that on a Space pool token, even though we add space pool-specific text as well.

## Implementer Checklist

<!--
Fill out the checklist below as applicable to your change. Bug fixes and new features must 
check off all of the required items.
-->

N/A