### PR TITLE
refactor: use balancers split code factory for smaller contract size

### DIFF
--- a/src/SpaceFactory.sol
+++ b/src/SpaceFactory.sol
@@ -44,13 +44,13 @@ contract SpaceFactory is BasePoolSplitCodeFactory, Trust {
     /// @notice Pool registry (adapter -> maturity -> pool address)
     mapping(address => mapping(uint256 => address)) public pools;
 
-    /// @dev Yieldspace config
-    uint256 internal ts;
-    uint256 internal g1;
-    uint256 internal g2;
+    /// @notice Yieldspace config
+    uint256 public ts;
+    uint256 public g1;
+    uint256 public g2;
 
-    /// @dev Oracle flag
-    bool internal oracleEnabled;
+    /// @notice Oracle flag
+    bool public oracleEnabled;
 
     constructor(
         IVault _vault,


### PR DESCRIPTION
## Motivation

Our Space Factory was too big with the `getEQReserves` reserves stuff added. In addition, #29 stands to add even more size, so we need room to breathe


## Solution

Similar to our [Roller Factory](https://github.com/sense-finance/auto-roller/blob/main/src/AutoRollerFactory.sol), we use Balancer's split code pattern to avoid storing the entire bytecode of the contract we're deploying in the factory itself